### PR TITLE
Provision the VM with the current Puppet Labs package signing key

### DIFF
--- a/provision/before/apt.sh
+++ b/provision/before/apt.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
 sudo sed -i 's,http://debian.yorku.ca/debian/,http://mirror.bytemark.co.uk/debian/,' /etc/apt/sources.list
+sudo apt-key adv --batch --keyserver pgp.mit.edu --recv-key '6F6B 1550 9CF8 E59E 6E46  9F32 7F43 8280 EF8D 349F'
 sudo aptitude update
 sudo aptitude upgrade -y


### PR DESCRIPTION
Otherwise the "aptitude update" and "upgrade" steps don't fully work
because apt can't verify the packages.