### PR TITLE
recursively clone repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ For information on using MetaCPAN, see [the api docs](https://github.com/metacpa
 ```bash
 git clone git://github.com/metacpan/metacpan-developer.git
 cd metacpan-developer
-sh bin/init.sh # clone all of the metacpan repos
+./bin/init.sh # recursively clone all of the metacpan repos
 vagrant up # start the VM - will download the base box (900M) on the first run
 vagrant provision # necessary installation and configuration
 ```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,35 +1,37 @@
 ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
 
 Vagrant.configure("2") do |config|
-  config.vm.box_url = "http://vmbox.metacpan.org/mcwheezy_vm_debian_006_32.box"
-  config.vm.box = "mcbase_006"
 
-  # Use METACPAN_DEVELOPER_* env vars to set vm hardware resources.
-  vbox_custom = %w[cpus memory].map do |hw|
-    key = "METACPAN_DEVELOPER_#{hw.upcase}"
-    ENV[key] ? ["--#{hw}", ENV[key]] : []
-  end.flatten
+    config.vm.box = "mcbase_006"
+    config.vm.box_url = "http://vmbox.metacpan.org/mcwheezy_vm_debian_006_32.box"
 
-  config.vm.provider :virtualbox do |vb|
-    vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
-    if not vbox_custom.empty?
-      vb.customize [ "modifyvm", :id, *vbox_custom ]
+    # Use METACPAN_DEVELOPER_* env vars to set vm hardware resources.
+    vbox_custom = %w[cpus memory].map do |hw|
+        key = "METACPAN_DEVELOPER_#{hw.upcase}"
+        ENV[key] ? ["--#{hw}", ENV[key]] : []
+    end.flatten
+
+    config.vm.provider :virtualbox do |vb|
+        vb.name = "mcstretch"
+        vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+        if not vbox_custom.empty?
+            vb.customize [ "modifyvm", :id, *vbox_custom ]
+        end
     end
-  end
 
-  config.vm.network "forwarded_port", guest: 5000, host: 5000 # api
-  config.vm.network "forwarded_port", guest: 5001, host: 5001 # www
-  config.vm.network "forwarded_port", guest: 5002, host: 5002 # gmc
-  config.vm.network "forwarded_port", guest: 80, host: 5080 # nginx http
-  config.vm.network "forwarded_port", guest: 443, host: 5443 # nginx https
-  config.vm.network "forwarded_port", guest: 9200, host: 9200 # production ES
-  config.vm.network "forwarded_port", guest: 9900, host: 9900 # test ES
+    config.vm.network "forwarded_port", guest: 5000, host: 5000 # api
+    config.vm.network "forwarded_port", guest: 5001, host: 5001 # www
+    config.vm.network "forwarded_port", guest: 5002, host: 5002 # gmc
+    config.vm.network "forwarded_port", guest: 80, host: 5080 # nginx http
+    config.vm.network "forwarded_port", guest: 443, host: 5443 # nginx https
+    config.vm.network "forwarded_port", guest: 9200, host: 9200 # production ES
+    config.vm.network "forwarded_port", guest: 9900, host: 9900 # test ES
 
-  config.vm.synced_folder "src/metacpan-puppet", "/etc/puppet"
-  config.vm.synced_folder "src/metacpan-api", "/home/vagrant/metacpan-api"
-  config.vm.synced_folder "src/metacpan-web", "/home/vagrant/metacpan-web"
-  config.vm.synced_folder "src/metacpan-explorer", "/home/vagrant/metacpan-explorer"
-  config.vm.synced_folder "src/github-meets-cpan", "/home/vagrant/github-meets-cpan"
+    config.vm.synced_folder "src/metacpan-puppet", "/etc/puppet", owner: "puppet", group: "puppet"
+    config.vm.synced_folder "src/metacpan-api", "/home/vagrant/metacpan-api"
+    config.vm.synced_folder "src/metacpan-web", "/home/vagrant/metacpan-web"
+    config.vm.synced_folder "src/metacpan-explorer", "/home/vagrant/metacpan-explorer"
+    config.vm.synced_folder "src/github-meets-cpan", "/home/vagrant/github-meets-cpan"
 
-  config.vm.provision :shell, :path => 'provision/all.sh'
+    config.vm.provision :shell, :path => 'provision/all.sh'
 end

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -1,19 +1,23 @@
-#!/bin/sh
+#!/bin/bash
+
+set -o errexit
+set -e -o pipefail
 
 mkdir -p src
-cd src
+pushd src
 
-git clone git://github.com/metacpan/metacpan-puppet.git
-git clone git://github.com/metacpan/metacpan-api.git
-git clone git://github.com/metacpan/metacpan-web.git
-git clone git://github.com/metacpan/metacpan-explorer.git
-git clone git://github.com/metacpan/github-meets-cpan.git
+git clone --recursive git://github.com/metacpan/github-meets-cpan.git
+git clone --recursive git://github.com/metacpan/metacpan-api.git
+git clone --recursive git://github.com/metacpan/metacpan-explorer.git
+git clone --recursive git://github.com/metacpan/metacpan-puppet.git
+git clone --recursive git://github.com/metacpan/metacpan-web.git
 
-cd metacpan-web
+# set up Git hooks
+pushd metacpan-web
 sh git/setup.sh
-cd ..
+popd
 
-cd metacpan-api
+pushd metacpan-api
 sh git/setup.sh
 
 if ! [ -e metacpan_server_local.conf ]; then


### PR DESCRIPTION
At least one of them has a submodule, so may as well handle them all this way.

Also, chown /etc/puppet to puppet:puppet as a precursor to stretch upgrade.